### PR TITLE
fix account update 認識違いを訂正

### DIFF
--- a/app/controllers/mypage/accounts_controller.rb
+++ b/app/controllers/mypage/accounts_controller.rb
@@ -1,10 +1,11 @@
 class Mypage::AccountsController < ApplicationController
   def edit
-    @user = current_user
+    @user = User.find(current_user.id)
   end
 
   def update
-    @user = current_user
+    # @user = current_user の場合validationエラーが起こった際に挙動がおかしくなってしまう
+    @user = User.find(current_user.id)
     if @user.update(account_params)
       redirect_to @user, notice: 'プロフィールを更新しました。'
     else


### PR DESCRIPTION
## account_controller 一部修正
```ruby
@user = current_user
⬇️
@user = find(current_user.id)
```
よろしくない挙動をしてしまうため変更

### 参考
[Issue 09 プロフィール更新の際の注意点について](https://tech-essentials.work/questions/119)